### PR TITLE
Raspbian

### DIFF
--- a/probe.yml
+++ b/probe.yml
@@ -30,11 +30,6 @@
     - role: driver
       when: ansible_distribution == "Kali"
 
-  tasks:
-     - name: Update driver for wireless adapter
-       shell: install-wifi
-       when: ansible_distribution != "Kali"
-
 - name: Set up and configure wifi probe
   hosts: all
   remote_user: root

--- a/probe.yml
+++ b/probe.yml
@@ -30,9 +30,16 @@
     - role: driver
       when: ansible_distribution == "Kali"
 
+  tasks:
+     - name: Update driver for wireless adapter
+       shell: install-wifi
+       when: ansible_distribution != "Kali"
+
 - name: Set up and configure wifi probe
   hosts: all
   remote_user: root
 
   roles:
     - role: common
+
+- name:

--- a/probe.yml
+++ b/probe.yml
@@ -41,5 +41,3 @@
 
   roles:
     - role: common
-
-- name:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -154,6 +154,10 @@
 - name: Enable control program
   service: name=wifi_probing enabled=yes state=restarted
 
+- name: Update driver for wireless adapter
+  shell: install-wifi
+  when: ansible_distribution != "Kali"
+
 - name: Set update flag to 0
   lineinfile: dest={{ script_dir }}/update regexp="^.*" line=0
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -128,6 +128,28 @@
     hour: "0"
     job: "/sbin/shutdown -r now"
 
+- name: Shutdown dongle upon unplugging wireless adapter
+  tasks:
+    - name: Find adapter
+      shell: lsusb | grep -i '2357:010C\|056E:4008\|2001:3311\|0DF6:0076\|2001:3310\|2001:330F\|07B8:8179\|0BDA:0179\|0BDA:8179\|0411:025D\|2019:AB32\|7392:A813\|056E:4007\|0411:0242\|0846:9052\|056E:400F\|056E:400E\|0E66:0023\|2001:3318\|2001:3314\|04BB:0953\|7392:A812\|7392:A811\|0BDA:0823\|0BDA:0820\|0BDA:A811\|0BDA:8822\|0BDA:0821\|0BDA:0811\|2357:0122\|148F:9097\|20F4:805B\|050D:1109\|2357:010D\|2357:0103\|2357:0101\|13B1:003F\|2001:3316\|2001:3315\|07B8:8812\|2019:AB30\|1740:0100\|1058:0632\|2001:3313\|0586:3426\|0E66:0022\|0B05:17D2\|0409:0408\|0789:016E\|04BB:0952\|0DF6:0074\|7392:A822\|2001:330E\|050D:1106\|0BDA:881C\|0BDA:881B\|0BDA:881A\|0BDA:8812\|2357:0109\|2357:0108\|2357:0107\|2001:3319\|0BDA:818C\|0BDA:818B\|148F:7650\|0B05:17D3\|0E8D:760A\|0E8D:760B\|13D3:3431\|13D3:3434\|148F:6370\|148F:7601\|148F:760A\|148F:760B\|148F:760C\|148F:760D\|2001:3D04\|2717:4106\|2955:0001\|2955:1001\|2955:1003\|2A5F:1000\|7392:7710\|0E8D:7650\|0E8D:7630\|2357:0105\|0DF6:0079\|0BDB:1011\|7392:C711\|20F4:806B\|293C:5702\|057C:8502\|04BB:0951\|07B8:7610\|0586:3425\|2001:3D02\|2019:AB31\|0DF6:0075\|0B05:17DB\|0B05:17D1\|148F:760A\|148F:761A\|7392:B711\|7392:A711\|0E8D:7610\|13B1:003E\|148F:7610\|0E8D:7662\|0E8D:7632\|0B05:17C9\|0E8D:7612\|045E:02E6\|0B05:17EB\|0846:9053\|0B05:180B\|0846:9014'
+      register: adapter
+
+    - name: Collect adapter id's
+      shell: echo "{{ adapter.stdout }}" | awk '{ print$6 }'
+      register: id
+
+    - name: Register vendor id
+      shell: echo "{{ id.stdout }}" | cut -d ':' -f 1
+      register: ID_VENDOR_ID
+
+    - name: Register model id
+      shell: echo "{{ id.stdout }}" | cut -d ':' -f 2
+      register: ID_MODEL_ID
+
+    - name: Add script for shutting down probe
+      shell: echo 'ACTION=="remove", ENV{ID_VENDOR_ID}=="{{ ID_VENDOR_ID.stdout }}", ENV{ID_MODEL_ID}=="{{ ID_MODEL_ID.stdout }}", RUN+="/sbin/shutdown -h now"' > /etc/udev/rules.d/00-dongle_shutdown.rules
+      when: "{{ adapter }}"
+
 - name: Change default password
   user: name=root password={{ root_pass }}
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -128,27 +128,25 @@
     hour: "0"
     job: "/sbin/shutdown -r now"
 
-- name: Shutdown dongle upon unplugging wireless adapter
-  tasks:
-    - name: Find adapter
-      shell: lsusb | grep -i '2357:010C\|056E:4008\|2001:3311\|0DF6:0076\|2001:3310\|2001:330F\|07B8:8179\|0BDA:0179\|0BDA:8179\|0411:025D\|2019:AB32\|7392:A813\|056E:4007\|0411:0242\|0846:9052\|056E:400F\|056E:400E\|0E66:0023\|2001:3318\|2001:3314\|04BB:0953\|7392:A812\|7392:A811\|0BDA:0823\|0BDA:0820\|0BDA:A811\|0BDA:8822\|0BDA:0821\|0BDA:0811\|2357:0122\|148F:9097\|20F4:805B\|050D:1109\|2357:010D\|2357:0103\|2357:0101\|13B1:003F\|2001:3316\|2001:3315\|07B8:8812\|2019:AB30\|1740:0100\|1058:0632\|2001:3313\|0586:3426\|0E66:0022\|0B05:17D2\|0409:0408\|0789:016E\|04BB:0952\|0DF6:0074\|7392:A822\|2001:330E\|050D:1106\|0BDA:881C\|0BDA:881B\|0BDA:881A\|0BDA:8812\|2357:0109\|2357:0108\|2357:0107\|2001:3319\|0BDA:818C\|0BDA:818B\|148F:7650\|0B05:17D3\|0E8D:760A\|0E8D:760B\|13D3:3431\|13D3:3434\|148F:6370\|148F:7601\|148F:760A\|148F:760B\|148F:760C\|148F:760D\|2001:3D04\|2717:4106\|2955:0001\|2955:1001\|2955:1003\|2A5F:1000\|7392:7710\|0E8D:7650\|0E8D:7630\|2357:0105\|0DF6:0079\|0BDB:1011\|7392:C711\|20F4:806B\|293C:5702\|057C:8502\|04BB:0951\|07B8:7610\|0586:3425\|2001:3D02\|2019:AB31\|0DF6:0075\|0B05:17DB\|0B05:17D1\|148F:760A\|148F:761A\|7392:B711\|7392:A711\|0E8D:7610\|13B1:003E\|148F:7610\|0E8D:7662\|0E8D:7632\|0B05:17C9\|0E8D:7612\|045E:02E6\|0B05:17EB\|0846:9053\|0B05:180B\|0846:9014'
-      register: adapter
+- name: Find wireless adapter
+  shell: lsusb | grep -i '2357:010C\|056E:4008\|2001:3311\|0DF6:0076\|2001:3310\|2001:330F\|07B8:8179\|0BDA:0179\|0BDA:8179\|0411:025D\|2019:AB32\|7392:A813\|056E:4007\|0411:0242\|0846:9052\|056E:400F\|056E:400E\|0E66:0023\|2001:3318\|2001:3314\|04BB:0953\|7392:A812\|7392:A811\|0BDA:0823\|0BDA:0820\|0BDA:A811\|0BDA:8822\|0BDA:0821\|0BDA:0811\|2357:0122\|148F:9097\|20F4:805B\|050D:1109\|2357:010D\|2357:0103\|2357:0101\|13B1:003F\|2001:3316\|2001:3315\|07B8:8812\|2019:AB30\|1740:0100\|1058:0632\|2001:3313\|0586:3426\|0E66:0022\|0B05:17D2\|0409:0408\|0789:016E\|04BB:0952\|0DF6:0074\|7392:A822\|2001:330E\|050D:1106\|0BDA:881C\|0BDA:881B\|0BDA:881A\|0BDA:8812\|2357:0109\|2357:0108\|2357:0107\|2001:3319\|0BDA:818C\|0BDA:818B\|148F:7650\|0B05:17D3\|0E8D:760A\|0E8D:760B\|13D3:3431\|13D3:3434\|148F:6370\|148F:7601\|148F:760A\|148F:760B\|148F:760C\|148F:760D\|2001:3D04\|2717:4106\|2955:0001\|2955:1001\|2955:1003\|2A5F:1000\|7392:7710\|0E8D:7650\|0E8D:7630\|2357:0105\|0DF6:0079\|0BDB:1011\|7392:C711\|20F4:806B\|293C:5702\|057C:8502\|04BB:0951\|07B8:7610\|0586:3425\|2001:3D02\|2019:AB31\|0DF6:0075\|0B05:17DB\|0B05:17D1\|148F:760A\|148F:761A\|7392:B711\|7392:A711\|0E8D:7610\|13B1:003E\|148F:7610\|0E8D:7662\|0E8D:7632\|0B05:17C9\|0E8D:7612\|045E:02E6\|0B05:17EB\|0846:9053\|0B05:180B\|0846:9014'
+  register: adapter
 
-    - name: Collect adapter id's
-      shell: echo "{{ adapter.stdout }}" | awk '{ print$6 }'
-      register: id
+- name: Collect adapter id's
+  shell: echo "{{ adapter.stdout }}" | awk '{ print$6 }'
+  register: id
 
-    - name: Register vendor id
-      shell: echo "{{ id.stdout }}" | cut -d ':' -f 1
-      register: ID_VENDOR_ID
+- name: Register vendor id
+  shell: echo "{{ id.stdout }}" | cut -d ':' -f 1
+  register: ID_VENDOR_ID
 
-    - name: Register model id
-      shell: echo "{{ id.stdout }}" | cut -d ':' -f 2
-      register: ID_MODEL_ID
+- name: Register model id
+  shell: echo "{{ id.stdout }}" | cut -d ':' -f 2
+  register: ID_MODEL_ID
 
-    - name: Add script for shutting down probe
-      shell: echo 'ACTION=="remove", ENV{ID_VENDOR_ID}=="{{ ID_VENDOR_ID.stdout }}", ENV{ID_MODEL_ID}=="{{ ID_MODEL_ID.stdout }}", RUN+="/sbin/shutdown -h now"' > /etc/udev/rules.d/00-dongle_shutdown.rules
-      when: "{{ adapter }}"
+- name: Add script for shutting down probe upon unplugging the wifi adapter
+  shell: echo 'ACTION=="remove", ENV{ID_VENDOR_ID}=="{{ ID_VENDOR_ID.stdout }}", ENV{ID_MODEL_ID}=="{{ ID_MODEL_ID.stdout }}", RUN+="/sbin/shutdown -h now"' > /etc/udev/rules.d/00-dongle_shutdown.rules
+  when: "{{ adapter }}"
 
 - name: Change default password
   user: name=root password={{ root_pass }}


### PR DESCRIPTION
Denne oppdateringen for å støtte Raspbian fra serverside er ferdig. Den sørger for å holde adapter drivere oppdatert ved å kjøre et script lagt inn på piene. I tillegg identifiserer den adapteren og legger inn et shutdown script basert på identiteten til adapteren. Scriptet som oppdaterer driverene "install-wifi", oppdaterer også seg selv automatisk når det forandres (oppdateringen er en del av scriptet), og vil kunne støtte adaptere som kommer ut i fremtiden. Kommandoene som identifiserer adapterne bruker id-er som er hentet fra install-wifi scriptet, og er bare statiske verdier. Dersom det er ønske om å også ha shutdown script for nye adaptere. Må man finne id til adapteren og legge den inn under Ansible tasken "Find wireless adapter" for at det skal legges inn.